### PR TITLE
Make pawns try exit cave before going to sleep on the floor

### DIFF
--- a/Source/JobGiver_Patch.cs
+++ b/Source/JobGiver_Patch.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace Shashlichnik
+{
+    public static class JobGiver_Patch
+    {
+        public static string[] overridingJobDefNames = new string[] { "LayDown" };
+
+        private static void TryOverrideJob(Pawn pawn, ref Job job)
+        {
+            // Log.Message($"job is [{job?.def?.defName}]");
+            if (job?.def?.defName is { } val
+                && overridingJobDefNames.Contains(val))
+            {
+                var caveComp = pawn.Map.GetComponent<CaveMapComponent>();
+                if (caveComp != null && caveComp.caveExit != null && caveComp.caveExit.Spawned &&
+                    caveComp.caveExit.exitIfNoJob)
+                {
+                    Log.Message($"Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
+                    var oldjob = job;
+                    JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
+                    // make a new one
+                    job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
+                }
+            }
+        }
+
+        // patch return result
+        [HarmonyLib.HarmonyPatch(typeof(JobGiver_GetRest), nameof(JobGiver_GetRest.TryGiveJob))]
+        internal static class GetRest_TryGiveJob_Patch
+        {
+            public static void Postfix(Pawn pawn, ref Job __result)
+            {
+                TryOverrideJob(pawn, ref __result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A patch that overrides job for sleeping on the floor to instead try get out of the cave.

I originally also wanted to fix the hunger issue, such that pawns also try to leave if looking for food. Unfortunately the way its coded means it isn't as easy as the sleeping task. I have had a look into how Gastronomy works with their dinning spot, and it seems the way to do it is through a fake 'NutrientPasteDispenser'... which would work, but a bit too big of a scope for me to tackle.

Note: Also haven't pushed new dlls.