### PR TITLE
Fix C# access modifier violations and Harmony patch issues

### DIFF
--- a/Source/Alert_CaveStability.cs
+++ b/Source/Alert_CaveStability.cs
@@ -46,7 +46,7 @@ namespace Shashlichnik
             }
             return sb.ToString();
         }
-        public override Color BGColor
+        protected override Color BGColor
         {
             get
             {

--- a/Source/CaveEntrance.cs
+++ b/Source/CaveEntrance.cs
@@ -66,7 +66,7 @@ namespace Shashlichnik
 
 
 
-        public override Texture2D EnterTex
+        protected override Texture2D EnterTex
         {
             get
             {
@@ -131,7 +131,7 @@ namespace Shashlichnik
         }
 #pragma warning restore 0618
 
-        public override void Tick()
+        protected override void Tick()
         {
             base.Tick();
             if (IsCollapsing)

--- a/Source/CaveExit.cs
+++ b/Source/CaveExit.cs
@@ -30,7 +30,7 @@ namespace Shashlichnik
             }
         }
 
-        public override Texture2D EnterTex
+        protected override Texture2D EnterTex
         {
             get
             {

--- a/Source/JobDriver_Dig.cs
+++ b/Source/JobDriver_Dig.cs
@@ -14,7 +14,7 @@ namespace Shashlichnik
         private Effecter graveDigEffect;
 
         public CaveEntrance CaveEntrance => TargetA.Thing as CaveEntrance;
-        public override IEnumerable<Toil> MakeNewToils()
+        protected override IEnumerable<Toil> MakeNewToils()
         {
             this.FailOnDestroyedOrNull(TargetIndex.A);
             this.FailOn(() => CaveEntrance.TicksToOpen <= 0 || CaveEntrance.IsCollapsing);

--- a/Source/JobGiver_DigClosestCluster.cs
+++ b/Source/JobGiver_DigClosestCluster.cs
@@ -20,7 +20,7 @@ namespace Shashlichnik
             ore = pawn.Map.listerThings.GetThingsOfType<Mineable>().Where(x => x.def != ThingDefOf.MineableSteel && x.def.building.isResourceRock && pawn.CanReserve(x)).OrderBy(m => (m.Position - pawn.Position).LengthHorizontalSquared).FirstOrDefault();
             return ore != null;
         }
-        public override Job TryGiveJob(Pawn pawn)
+        protected override Job TryGiveJob(Pawn pawn)
         {
             if (TryFindClosestOre(pawn, out Thing ore))
             {

--- a/Source/JobGiver_DrinkBeer.cs
+++ b/Source/JobGiver_DrinkBeer.cs
@@ -25,7 +25,7 @@ namespace Shashlichnik
 
             return 0f;
         }
-        public override Job TryGiveJob(Pawn pawn)
+        protected override Job TryGiveJob(Pawn pawn)
         {
             if (pawn.health.hediffSet.GetFirstHediffOfDef(HediffDefOf.AlcoholHigh) != null)
             {

--- a/Source/JobGiver_ExitMapPortal.cs
+++ b/Source/JobGiver_ExitMapPortal.cs
@@ -11,7 +11,7 @@ namespace Shashlichnik
 {
     public class JobGiver_ExitMapPortal : JobGiver_ExitMapBest
     {
-        public override Job TryGiveJob(Pawn pawn)
+        protected override Job TryGiveJob(Pawn pawn)
         {
             var job = base.TryGiveJob(pawn);
             if (job != null)
@@ -47,7 +47,7 @@ namespace Shashlichnik
                 return null;
             }
         }
-        public override bool TryFindGoodExitDest(Pawn pawn, bool canDig, bool canBash, out IntVec3 dest)
+        protected override bool TryFindGoodExitDest(Pawn pawn, bool canDig, bool canBash, out IntVec3 dest)
         {
             var exits = pawn.Map.listerThings.GetThingsOfType<CaveExit>().Where(x => x.caveEntrance != null);
             Log.Message($"Trying to find exit. Found any {exits.Any()} ({exits.FirstOrDefault()?.Position})");

--- a/Source/JobGiver_ExitMap_Patch.cs
+++ b/Source/JobGiver_ExitMap_Patch.cs
@@ -9,7 +9,7 @@ using Verse.AI;
 
 namespace Shashlichnik
 {
-    [HarmonyLib.HarmonyPatch(typeof(JobGiver_ExitMap), nameof(JobGiver_ExitMap.TryGiveJob))]
+    [HarmonyLib.HarmonyPatch(typeof(JobGiver_ExitMap), "TryGiveJob")]
     internal static class JobGiver_ExitMap_Patch //Similar functionally was added at 1.6 tho
     {
         public static bool Prefix(Pawn pawn, ref Job __result)

--- a/Source/JobGiver_LootAround.cs
+++ b/Source/JobGiver_LootAround.cs
@@ -16,7 +16,7 @@ namespace Shashlichnik
         {
             return 8.6f;
         }
-        public override Job TryGiveJob(Pawn pawn)
+        protected override Job TryGiveJob(Pawn pawn)
         {
             if (TryFindBestItemToSteal(pawn.Position, pawn.Map, 9.9f, out var item, pawn))
             {


### PR DESCRIPTION
# Add version-specific Tick() access modifier and fix C# access modifier violations

## Summary

- Add version-specific Tick() access modifier and include built assemblies.
- Fix C# access modifier violations and Harmony patch issues.

## Changes
- CaveEntrance.Tick() now uses protected override for v1.6 and public override for v1.5.
- Compiled DLLs for RimWorld 1.5 and 1.6 are included for testing.
- Changed public override to protected override for methods overriding protected base members.
- Harmony patches now use string literals instead of nameof() for protected methods.
- These changes improve code correctness and compilation.

## Testing
- I'm not sure how exactly to test this mod, but I was able to start the game without errors. I popped into the devtest world and I popped down two caves: one that was manually by a colonist and another that I just debugged. Finished. Everything is working as it did before I made any changes, so it looks like the mod is working correctly. 

## Motivation
I got some bugs in my own game which I wanted to try to fix, but I saw that I couldn't compile because I'm using Mac OS and I don't have Visual Studio. So, my compiler does not fix these access issues on build. 

These changes should be compatible with the same version that the mod is using of C# and.NET, so there shouldn't be any compatibility issues. I've attached the DLL for both 1.5 and 1.6 which you can try out and verify that work. Additionally, you should try to build the project yourself and see that it self-compiles with your version of .NET.

I didn't commit my local config changes to the.NET SDK that I use to compile because I reckon you would prefer to work with your environment, which already is proven to work. I can do that if you want to, but for now, I think these code changes are sufficient. 

Thanks!